### PR TITLE
Make parsers, serializers and Content-Types extensible

### DIFF
--- a/request.go
+++ b/request.go
@@ -49,6 +49,28 @@ func (r *Request) Bytes(Data []byte) *Request {
 	return r
 }
 
+// Serializer is a request body serializer.
+type Serializer struct {
+	Encode      func(data interface{}) ([]byte, error)
+	ContentType string
+}
+
+// Serialize sets response headers and calls Bytes with the serialized body.
+func (r *Request) Serialize(data interface{}, serializer Serializer) *Request {
+	if r.Error != nil {
+		return r
+	}
+	res, err := serializer.Encode(data)
+	if err != nil {
+		r.Error = &err
+		return r
+	}
+	r.Headers["Content-Length"] = strconv.Itoa(len(res))
+	r.Headers["Content-Type"] = serializer.ContentType
+	r.Bytes(res)
+	return r
+}
+
 // JSON sets the data to the JSON specified.
 func (r *Request) JSON(Data interface{}) *Request {
 	if r.Error != nil {

--- a/response.go
+++ b/response.go
@@ -14,6 +14,23 @@ type Response struct {
 	RawResponse *http.Response
 }
 
+// Parser is a response body parser. These can be found in the parsers package.
+type Parser func(responseBytes []byte, into interface{}) error
+
+// Parse parses the response body's bytes with a Parser.
+func (r *Response) Parse(parser Parser) (interface{}, error) {
+	b, err := r.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	var BasicInterface interface{}
+	err = parser(b, &BasicInterface)
+	if err != nil {
+		return nil, err
+	}
+	return BasicInterface, nil
+}
+
 // Bytes gets the response as bytes.
 func (r *Response) Bytes() ([]byte, error) {
 	return ioutil.ReadAll(r.RawResponse.Body)

--- a/response.go
+++ b/response.go
@@ -14,7 +14,7 @@ type Response struct {
 	RawResponse *http.Response
 }
 
-// Parser is a response body parser. These can be found in the parsers package.
+// Parser is a response body parser. These can be found in the data package.
 type Parser func(responseBytes []byte, into interface{}) error
 
 // Parse parses the response body's bytes with a Parser.


### PR DESCRIPTION
This adds `Serializer`, `Parser`, `Serialize` and `Parse`. Previously, using Content-Types other than JSON was relatively painful; this adds a simple way to construct your own helpers.

It's probably best that `JSON`, etc, are changed so they're aliases of `Response.Parse(data.ParseJSON)` or something similar. I haven't created a `data` package because I'm not sure if it should be added or not, but it's referenced in [one comment](https://github.com/fjah/structuredhttp/blob/master/response.go#L17). This makes the PR WIP.